### PR TITLE
fix: Fix handling of github url (#236)

### DIFF
--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -141,7 +141,7 @@ def read_config(
         github_username = config.get("ghstack", "github_username")
     if github_username is None and github_oauth is not None:
         request_url: str
-        if "{github_url}" == "github.com":
+        if github_url == "github.com":
             request_url = f"https://api.{github_url}/user"
         else:
             request_url = f"https://{github_url}/api/v3/user"
@@ -153,6 +153,7 @@ def read_config(
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
+        res.raise_for_status()
         github_username = res.json()["login"]
         config.set("ghstack", "github_username", github_username)
         write_back = True

--- a/ghstack/github_real.py
+++ b/ghstack/github_real.py
@@ -17,19 +17,21 @@ class RealGitHubEndpoint(ghstack.github.GitHubEndpoint):
     """
 
     # The URL of the GraphQL endpoint to connect to
-    graphql_endpoint: str
-    if "{github_url}" == "github.com":
-        graphql_endpoint = "https://api.{github_url}/graphql"
-    else:
-        graphql_endpoint = "https://{github_url}/api/graphql"
+    @property
+    def graphql_endpoint(self) -> str:
+        if self.github_url == "github.com":
+            return f"https://api.{self.github_url}/graphql"
+        else:
+            return f"https://{self.github_url}/api/graphql"
 
     # The base URL of the REST endpoint to connect to (all REST requests
     # will be subpaths of this URL)
-    rest_endpoint: str
-    if "{github_url}" == "github.com":
-        rest_endpoint = "https://api.{github_url}"
-    else:
-        rest_endpoint = "https://{github_url}/api/v3"
+    @property
+    def rest_endpoint(self) -> str:
+        if self.github_url == "github.com":
+            return f"https://api.{self.github_url}"
+        else:
+            return f"https://{self.github_url}/api/v3"
 
     # The base URL of regular WWW website, in case we need to manually
     # interact with the real website


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3
* #2
* __->__ #1

Fix for https://github.com/ezyang/ghstack/pull/235.

Add `res.raise_for_status()` so that request failures result in a better
exception (instead of failing to parse the response json).