### PR TITLE
feat: Request token at `repo` scope (#237)

### DIFF
--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -100,7 +100,7 @@ def read_config(
         res = requests.post(
             f"https://{github_url}/login/device/code",
             headers={"Accept": "application/json"},
-            data={"client_id": CLIENT_ID, "scope": "public_repo"},
+            data={"client_id": CLIENT_ID, "scope": "repo"},
         )
         data = res.json()
         print(f"User verification code: {data['user_code']}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3
* __->__ #2
* #1

Request `repo` instead of `public_repo` scope token to allow `ghstack`
to be used in private repositories.

Fixes #234